### PR TITLE
Remove surprising ws cleanup before-save-hook

### DIFF
--- a/init.el
+++ b/init.el
@@ -140,9 +140,6 @@
   (global-whitespace-mode 1)
   (setq-default tab-width 4 indent-tabs-mode nil))
 
-;;; cleanup whitespace before file save
-(add-hook 'before-save-hook 'whitespace-cleanup)
-
 (use-package hl-line
   :config
   (global-hl-line-mode 1)


### PR DESCRIPTION
This config should not be global as it would be active for every major mode.
